### PR TITLE
Add magic-enter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A curation of plugins, prompts, and resources for the [friendly interactive shel
 - [Async Prompt](https://github.com/acomagu/fish-async-prompt) - Make your prompt asynchronous.
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2.
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them.
+- [Magic-Enter](https://github.com/mattmc3/magic-enter.fish) - Run a default command when no command was given
 
 ## Docker
 


### PR DESCRIPTION
Added Magic-Enter to the plugin list. For OMZ users, this is the fish version of this plugin: https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/magic-enter