### PR TITLE
Add web-search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them
 - [Base16 Fish](https://github.com/FabioAntunes/base16-fish-shell) - A pure Fish solution to change your shell's default ANSI colors
+- [Web Search](https://github.com/Veirt/web-search.fish) - A plugin to do a web search via fish. Inspired by [`oh-my-zsh/web-search`](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/web-search)
 
 ## Docker
 


### PR DESCRIPTION
This plugin is fish version of [`oh-my-zsh/web-search`](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/web-search).