### PR TITLE
Add Fish AI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 - [Apple Touchbar](https://github.com/rodrigobdz/fish-apple-touchbar) - Customize your [Touch Bar](https://developer.apple.com/design/human-interface-guidelines/macos/touch-bar/touch-bar-overview) in iTerm2
 - [Abbreviation Tips](https://github.com/Gazorby/fish-abbreviation-tips) - Remembering abbreviations by displaying tips when you can use them
 - [Base16 Fish](https://github.com/FabioAntunes/base16-fish-shell) - A pure Fish solution to change your shell's default ANSI colors
+- [Fish AI](https://github.com/Realiserad/fish-ai) - Supercharge your command line with LLMs and get shell scripting assistance in Fish
 
 ## Docker
 


### PR DESCRIPTION
`fish-ai` adds AI functionality to Fish. It has been tested with macOS and Linux.

Originally based on [Tom Dörr's fish.codex repository](https://github.com/tom-doerr/codex.fish), but with some additional functionality.

It can be hooked up to OpenAI, Azure OpenAI, Google, Hugging Face, Mistral or a self-hosted LLM behind any OpenAI-compatible API. It provides keyboard bindings for completing commands and converting a comment into a command and vice versa.

Link to the repository: https://github.com/Realiserad/fish-ai