### PR TITLE
Remove dead link from the overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 
 - [Official Site](https://fishshell.com)
 - [GitHub Repository](https://github.com/fish-shell/fish-shell)
-- [Try in browser!](https://rootnroll.com/d/fish-shell/) 🍤
 
 ## Community Resources
 


### PR DESCRIPTION
Remove "Try in browser" link as it is dead.
I could not find any replacement to the old page.