### PR TITLE
Add Omafish plugin to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 - [Fundle](https://github.com/danhper/fundle) - `config.fish`-based plugin manager
 - [GitNow](https://github.com/joseluisq/gitnow) - A collection of utility functions to speed up your git workflow
 - [Sponge](https://github.com/meaningful-ooo/sponge) - Clean command history from typos automatically
+- [Omafish](https://github.com/crmne/omafish) - Recreates DHH's Omarchy Bash setup inside fish shell.
 - [Autopair](https://github.com/jorgebucaran/autopair.fish) - Auto-complete matching pairs in the Fish command-line. ([Alternative](https://github.com/laughedelic/pisces))
 - [Getopts](https://github.com/jorgebucaran/getopts.fish) - CLI options parser (alternative to the [`argparse`](https://fishshell.com/docs/current/cmds/argparse.html) builtin)
 - [Fishtape](https://github.com/jorgebucaran/fishtape) - TAP-based test runner for Fish


### PR DESCRIPTION
Recreates [David Heinemeier Hansson](https://dhh.dk/)'s [Omarchy](https://omarchy.org) Bash setup inside fish shell

The goal is a 1:1 experience so you can follow DHH's dotfiles and muscle memory while enjoying fish ergonomics.
