### PR TITLE
Add fish-session to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Welcome to the ultimate treasure trove of handpicked plugins, prompts, and other
 
 - [z](https://github.com/jethrokuan/z) - Pure-Fish [`rupa/z`](https://github.com/rupa/z)-like directory jumping
 - [fzf](https://github.com/PatrickF1/fzf.fish) - Ef-🐟-ient key bindings for [`junegunn/fzf`](https://github.com/junegunn/fzf). ([Alternative](https://github.com/jethrokuan/fzf))
+- [fish-session](https://github.com/AtefR/fish-session) - UI-first session manager for Fish with persistent sessions and fast reattach
 - [nvm](https://github.com/jorgebucaran/nvm.fish) - Node.js version manager lovingly made for Fish
 - [Done](https://github.com/franciscolourenco/done) - Automatically receive notifications after a long process finishes
 - [Replay](https://github.com/jorgebucaran/replay.fish) - Run Bash commands replaying changes in Fish. ([Alternative](https://github.com/edc/bass))


### PR DESCRIPTION
Hi, I'm adding fish-session to the Plugins section.

  - Plugin: https://github.com/AtefR/fish-session
  - Description: UI-first session manager for Fish with persistent sessions and fast reattach